### PR TITLE
dug: rfc9462 4.3 opportunistic discovery

### DIFF
--- a/dnsext-dox/DNS/DoX/SAN.hs
+++ b/dnsext-dox/DNS/DoX/SAN.hs
@@ -20,6 +20,7 @@ makeOnServerCertificate Nothing = validateDefault
 makeOnServerCertificate (Just ip) = f
   where
     f caStore validCache sid cc
+        | any (isTrusted ip) defaultTrusted = return []
         | ip `elem` ips = validateDefault caStore validCache sid cc
         | otherwise = return [InvalidName $ show ip ++ " is not included in " ++ show ips]
       where
@@ -45,3 +46,25 @@ toIP bs
     ws = BS.unpack bs
     len = length ws
     is = map fromIntegral ws
+
+-- RFC9462 4.3. Opportunistic Discovery
+-- private IP addresses [RFC1918], Unique Local Addresses (ULAs) [RFC4193],
+-- and Link-Local addresses [RFC3927] [RFC4291] cannot be safely confirmed
+-- using TLS certificates under most conditions.
+defaultTrusted :: [IP.IPRange]
+defaultTrusted = map read
+    [ "127.0.0.0/8"
+    , "10.0.0.0/8"
+    , "169.254.0.0/16"
+    , "172.16.0.0/12"
+    , "192.168.0.0/16"
+    , "::1/128"
+    , "fc00::/7"
+    , "fe80::/10"
+    ]
+
+isTrusted :: IP -> IP.IPRange -> Bool
+isTrusted (IPv4 ip) (IP.IPv4Range r) = ip `IP.isMatchedTo` r
+isTrusted (IPv6 ip) (IP.IPv6Range r) = ip `IP.isMatchedTo` r
+isTrusted (IPv4 ip) (IP.IPv6Range r) = IP.ipv4ToIPv6 ip `IP.isMatchedTo` r
+isTrusted _ _ = False


### PR DESCRIPTION
ip addresses which cannot be included in TLS SAN field SHOULD not be used for verified discovery of DDR, so exclude it upon dug -e is specified.