### PR TITLE
pkg: use cloudsmith for the debian repository

### DIFF
--- a/.github/workflows/bowline.yml
+++ b/.github/workflows/bowline.yml
@@ -139,20 +139,17 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
           ${{ env.PACKAGE_FILENAME }}
-    - uses: ruby/setup-ruby@v1
+    - name: release to cloudsmith
       if: gitHub.event_name == 'release' && runner.os == 'linux'
+      id: push
+      uses: cloudsmith-io/action@master
       with:
-        ruby-version: 2.7
-    - name: release to packagecloud.io
-      if: gitHub.event_name == 'release' && runner.os == 'linux'
-      run: |
-        # Instsall packagecloud CLI
-        gem install package_cloud
-        # push all versions and delete it in advance
-        for distro_version in ${{ env.DISTRO_LIST }} ; do
-            package_cloud yank ukontainer/bowline/$distro_version ${{ env.PACKAGE_FILENAME }} || true
-            package_cloud push ukontainer/bowline/$distro_version ${{ env.PACKAGE_FILENAME }}
-        done
-      env:
-        PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-        DISTRO_LIST: "debian/bookworm"
+        api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+        command: "push"
+        format: "deb"
+        owner: "iijlab"
+        repo: "bowline"
+        distro: "debian"
+        release: "bookworm"
+        republish: "true" # needed ONLY if version is not changing
+        file: ${{ env.PACKAGE_FILENAME }}

--- a/docs/bowline.md
+++ b/docs/bowline.md
@@ -23,6 +23,18 @@ rank: 2
 
 * [Binaries are available](https://github.com/iijlab/dnsext/releases)
 
+## Installation
+
+We have a debian package hosted on public repository; follow the instruction below to install.
+
+```
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/iijlab/bowline/setup.deb.sh' \
+  | sudo -E bash
+sudo apt-get update
+sudo apt-get install bowline
+```
+
 ## Configuration
 
 * [`bowline.conf`](https://github.com/iijlab/dnsext/blob/main/dnsext-bowline/bowline/bowline.conf)

--- a/docs/dug.md
+++ b/docs/dug.md
@@ -19,6 +19,16 @@ Futher readings:
 
 - [DNS検索コマンドdugの紹介](https://eng-blog.iij.ad.jp/archives/27527)
 
+## Installation
+
+`dug` command can be installed via homebrew.
+
+```
+brew install iijlab/tap/dug
+```
+
+
+
 ## Recursive query
 
 ### Basic


### PR DESCRIPTION
also added README description for the installation instruction. With this we need to add CLOUDSMITH_API_KEY to the repository secret.