### PR TITLE
Fix polling leak

### DIFF
--- a/dnsext-bowline/ddrd/ddrd.hs
+++ b/dnsext-bowline/ddrd/ddrd.hs
@@ -222,8 +222,8 @@ main = do
                     , send = \(bs, sa) -> void $ NSB.sendTo s bs sa
                     , recv = NSB.recvFrom s 2048
                     , wait = do
-                        wait' <- waitReadSocketSTM s
-                        atomically wait'
+                        (wait', cancel) <- waitAndCancelReadSocketSTM s
+                        atomically wait' `E.onException` cancel
                     , putLog = putL
                     }
         void $ forkIO $ do

--- a/dnsext-iterative/DNS/Iterative/Server/QUIC.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/QUIC.hs
@@ -44,10 +44,11 @@ quicServers VcServerConfig{..} env toCacher ss = do
         info <- QUIC.getConnectionInfo conn
         let mysa = QUIC.localSockAddr info
             peersa = QUIC.remoteSockAddr info
-            waitInput = return $ do
+            waitInput = do
                 isEmpty <- isEmptyTQueue $ QUIC.inputQ conn
                 retryUntil $ not isEmpty
-        (vcSess, toSender, fromX) <- initVcSession waitInput
+            cancel = return ()
+        (vcSess, toSender, fromX) <- initVcSession $ return (waitInput, cancel)
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
             let recv = do
                     strm <- QUIC.acceptStream conn

--- a/dnsext-iterative/DNS/Iterative/Server/TCP.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TCP.hs
@@ -19,7 +19,7 @@ import qualified DNS.ThreadStats as TStat
 
 -- other packages
 import Network.Run.TCP
-import Network.Socket (getPeerName, getSocketName, waitReadSocketSTM)
+import Network.Socket (getPeerName, getSocketName, waitAndCancelReadSocketSTM)
 import qualified Network.Socket.ByteString as Network
 
 -- this package
@@ -50,7 +50,7 @@ tcpServer VcServerConfig{..} env toCacher s = do
         peersa <- getPeerName sock
         logLn env Log.DEBUG $ "tcp-srv: accept: " ++ show peersa
         let peerInfo = PeerInfoVC peersa
-        (vcSess, toSender, fromX) <- initVcSession (waitReadSocketSTM sock)
+        (vcSess, toSender, fromX) <- initVcSession $ waitAndCancelReadSocketSTM sock
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
             recv <- makeNBRecvVC maxSize $ Network.recv sock
             let onRecv bs = do

--- a/dnsext-iterative/DNS/Iterative/Server/TLS.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TLS.hs
@@ -52,7 +52,9 @@ tlsServer VcServerConfig{..} env toCacher s = do
             peersa = H2.peerSockAddr backend
             peerInfo = PeerInfoVC peersa
         logLn env Log.DEBUG $ "tls-srv: accept: " ++ show peersa
-        (vcSess, toSender, fromX) <- initVcSession (pure $ pure ())
+        let waitInput = return ()
+            cancel = return ()
+        (vcSess, toSender, fromX) <- initVcSession $ return (waitInput, cancel)
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
             recv <- makeNBRecvVCNoSize maxSize $ H2.recv backend
             let onRecv bs = do


### PR DESCRIPTION
This ensures to call `cancel` to prevent leaks in IO Manager.