### PR TITLE
making Show SVCB more compatible with the RFC 9460 sytle

### DIFF
--- a/dnsext-svcb/DNS/SVCB/Params.hs
+++ b/dnsext-svcb/DNS/SVCB/Params.hs
@@ -1,6 +1,5 @@
 module DNS.SVCB.Params where
 
-import DNS.SVCB.Imports
 import DNS.SVCB.Key
 import DNS.SVCB.Value
 import Data.IntMap.Strict (IntMap)
@@ -9,7 +8,7 @@ import qualified Data.IntMap.Strict as M
 newtype SvcParams = SvcParams (IntMap SvcParamValue) deriving (Eq, Ord)
 
 instance Show SvcParams where
-    show (SvcParams m) = "{" ++ intercalate ", " (M.foldrWithKey f [] m) ++ "}"
+    show (SvcParams m) = unwords $ M.foldrWithKey f [] m
       where
         showkv k v =
             show (toSvcParamKey $ fromIntegral k)

--- a/dnsext-svcb/DNS/SVCB/SVCB.hs
+++ b/dnsext-svcb/DNS/SVCB/SVCB.hs
@@ -27,7 +27,10 @@ data RD_SVCB = RD_SVCB
     , svcb_target :: Domain
     , svcb_params :: SvcParams
     }
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord)
+
+instance Show RD_SVCB where
+    show RD_SVCB{..} = show svcb_priority ++ " " ++ show svcb_target ++ " " ++ show svcb_params
 
 instance ResourceData RD_SVCB where
     resourceDataType _ = SVCB
@@ -74,7 +77,10 @@ data RD_HTTPS = RD_HTTPS
     , https_target :: Domain
     , https_params :: SvcParams
     }
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord)
+
+instance Show RD_HTTPS where
+    show RD_HTTPS{..} = show https_priority ++ " " ++ show https_target ++ " " ++ show https_params
 
 instance ResourceData RD_HTTPS where
     resourceDataType _ = HTTPS

--- a/dnsext-utils/DNS/ZoneFile/Parser.hs
+++ b/dnsext-utils/DNS/ZoneFile/Parser.hs
@@ -21,10 +21,10 @@ import Data.IP (IPv4, IPv6)
 -- this package
 import DNS.Parser hiding (Parser, runParser)
 import qualified DNS.Parser as Poly
-import DNS.ZoneFile.Types
 import DNS.ZoneFile.ParserBase
 import DNS.ZoneFile.ParserDNSSEC
 import DNS.ZoneFile.ParserSVCB
+import DNS.ZoneFile.Types
 
 {- FOURMOLU_DISABLE -}
 data Context =
@@ -255,7 +255,7 @@ rrclass = optional (blank *> class_) >>= maybe (gets cx_class) setClass
 -- >>> -- * URL: https://datatracker.ietf.org/doc/html/rfc9460#name-servicemode-3
 -- >>> -- * example RR: example.com.   SVCB   16 foo.example.org. alpn="f\\\\oo\\,bar,h2"
 -- >>> runParser (rrTyRData (,)) cx [Blank,CS "SVCB",Blank,CS "16",Blank,CS "foo",Dot,CS "example",Dot,CS "org",Dot,Blank,CS "alpn=",CS (estringToCS' [C 102,E 92,C 111,C 111,E 44,C 98,C 97,C 114,C 44,C 104,C 50])]
--- Right (((SVCB,RD_SVCB {svcb_priority = 16, svcb_target = "foo.example.org.", svcb_params = {alpn=["f\\oo,bar","h2"]}}),Context "." "." 3600 IN),[])
+-- Right (((SVCB,16 "foo.example.org." alpn=["f\\oo,bar","h2"]),Context "." "." 3600 IN),[])
 rrTyRData :: (TYPE -> RData -> a) -> Parser a
 rrTyRData mk =
     blank *>
@@ -318,7 +318,7 @@ file = many (record <* this RSep)
 -- >>> parseLineRR [Dot,Blank,CS "IN",Blank,CS "DS",Blank,CS "20326",Blank,CS "8",Blank,CS "2",Blank,CS "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"] defaultContext
 -- Right (ResourceRecord {rrname = ".", rrtype = DS, rrclass = IN, rrttl = 1800(30 mins), rdata = RD_DS {ds_key_tag = 20326, ds_pubalg = RSASHA256, ds_digestalg = SHA256, ds_digest = \# 32 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d}},Context "." "." 1800 IN)
 -- >>> parseLineRR [CS "_dns",Dot,CS "resolver",Dot,CS "arpa",Dot,Blank,CS "300",Blank,CS "IN",Blank,CS "SVCB",Blank,CS "1",Blank,CS "ns",Dot,CS "example",Dot,Blank,CS "alpn=",CS "h2,h3",Blank,CS "ipv4hint=192.0.2.19",Blank,CS "ipv6hint=2001:db8::13"] defaultContext
--- Right (ResourceRecord {rrname = "_dns.resolver.arpa.", rrtype = SVCB, rrclass = IN, rrttl = 300(5 mins), rdata = RD_SVCB {svcb_priority = 1, svcb_target = "ns.example.", svcb_params = {alpn=["h2","h3"], ipv4hint=[192.0.2.19], ipv6hint=[2001:db8::13]}}},Context "." "_dns.resolver.arpa." 300 IN)
+-- Right (ResourceRecord {rrname = "_dns.resolver.arpa.", rrtype = SVCB, rrclass = IN, rrttl = 300(5 mins), rdata = 1 "ns.example." alpn=["h2","h3"] ipv4hint=[192.0.2.19] ipv6hint=[2001:db8::13]},Context "." "_dns.resolver.arpa." 300 IN)
 parseLineRR :: [Token] -> Context -> Either String (ResourceRecord, Context)
 parseLineRR ts icontext = fst <$> runParser (zoneRR <* eof) icontext ts
 


### PR DESCRIPTION
This PR hopefully makes SVCB RR more readable:

Current:

```
_dns.resolver.arpa.	300(5 mins)	IN	SVCB	RD_SVCB {svcb_priority = 1, svcb_target = "one.one.one.one.", svcb_params = {alpn=["h2","h3"], port=443, ipv4hint=[1.1.1.1,1.0.0.1], ipv6hint=[2606:4700:4700::1111,2606:4700:4700::1001], dohpath="/dns-query{?dns}"}}
_dns.resolver.arpa.	300(5 mins)	IN	SVCB	RD_SVCB {svcb_priority = 2, svcb_target = "one.one.one.one.", svcb_params = {alpn=["dot"], port=853, ipv4hint=[1.1.1.1,1.0.0.1], ipv6hint=[2606:4700:4700::1111,2606:4700:4700::1001]}}
```

New:

```
_dns.resolver.arpa.	300(5 mins)	IN	SVCB	1 "one.one.one.one." alpn=["h2","h3"] port=443 ipv4hint=[1.1.1.1,1.0.0.1] ipv6hint=[2606:4700:4700::1111,2606:4700:4700::1001] dohpath="/dns-query{?dns}"
_dns.resolver.arpa.	300(5 mins)	IN	SVCB	2 "one.one.one.one." alpn=["dot"] port=853 ipv4hint=[1.1.1.1,1.0.0.1] ipv6hint=[2606:4700:4700::1111,2606:4700:4700::1001]
```

One concern is that the current format is already used in https://eng-blog.iij.ad.jp/archives/31843