### PR TITLE
doq: configure the quic payload size to 1200

### DIFF
--- a/dnsext-dox/DNS/DoX/QUIC.hs
+++ b/dnsext-dox/DNS/DoX/QUIC.hs
@@ -97,4 +97,5 @@ getQUICParams ResolveInfo{..} tag alpn0 = do
                             ~msg = ver ++ "(" ++ mode ++ ")"
                         ractionOnConnectionInfo rinfoActions tag msg
                     }
+            , ccPacketSize = Just 1200
             }

--- a/dnsext-dox/dnsext-dox.cabal
+++ b/dnsext-dox/dnsext-dox.cabal
@@ -48,8 +48,8 @@ library
         http2-tls >= 0.4.8 && < 0.5,
         http3 >= 0.1 && < 0.2,
         iproute,
-        network >= 3.2.2 && < 3.3,
-        quic >= 0.2.15 && < 0.3,
+        network >= 3.2.8 && < 3.3,
+        quic >= 0.2.19 && < 0.3,
         serialise,
         tls >= 2.1.10
 


### PR DESCRIPTION
under the environment where the intermediate path uses mtu=1280, doq packets are dropped if PMTUD doesn't work.  This is the case with tailscale and cilium k8s CNI (ICMP is somehow filtered).

This commit uses 1200 bytes for the quic payload under bowline, dug, and ddrd.  This also requires new version of network library (for DF bit configuration) and quic library (to configure ccPacketSize parameter).