### PR TITLE
Exit 0 if RRs exists

### DIFF
--- a/dnsext-bowline/dug/Recursive.hs
+++ b/dnsext-bowline/dug/Recursive.hs
@@ -194,8 +194,10 @@ runUDP
     -> [(Question, QueryControls)]
     -> IO ()
 runUDP printHeader conf putLnSTM putLinesSTM qcs = withLookupConf conf $ \LookupEnv{..} -> do
-    let printIt (q, ctl) = resolve lenvResolveEnv q ctl >>= atomically . printReplySTM printHeader putLnSTM putLinesSTM
-    mapM_ printIt qcs
+    let resolveAndPrint (q, ctl) = do
+            erply <- resolve lenvResolveEnv q ctl
+            atomically $ printReplySTM printHeader putLnSTM putLinesSTM erply
+    mapM_ resolveAndPrint qcs
 
 runVC
     :: Bool


### PR DESCRIPTION
With this PR, we can use `dug` in a shell script like this:

```
if dug $(dom) a 1> /dev/null 2>&1; then
```

Discussion: should we provide a command-line option to change the behavior of exit status?