### PR TITLE
Ignore end-of-line comments in resolv.conf

### DIFF
--- a/dnsext-do53/DNS/Do53/System.hs
+++ b/dnsext-do53/DNS/Do53/System.hs
@@ -40,6 +40,6 @@ getDefaultDnsServers file = toAddresses <$> readFile file
     toAddresses :: String -> [String]
     toAddresses cs = map extract (filter ("nameserver" `isPrefixOf`) (lines cs))
     extract = takeWhile (not . isEnd) . dropWhile isSpace . drop 11
-    isEnd = or . sequence [isSpace, (==) '#']
+    isEnd = or . sequence [isSpace, (==) '#', (==) ';']
 
 #endif

--- a/dnsext-do53/DNS/Do53/System.hs
+++ b/dnsext-do53/DNS/Do53/System.hs
@@ -39,6 +39,7 @@ getDefaultDnsServers file = toAddresses <$> readFile file
   where
     toAddresses :: String -> [String]
     toAddresses cs = map extract (filter ("nameserver" `isPrefixOf`) (lines cs))
-    extract = reverse . dropWhile isSpace . reverse . dropWhile isSpace . drop 11
+    extract = takeWhile (not . isEnd) . dropWhile isSpace . drop 11
+    isEnd = or . sequence [isSpace, (==) '#']
 
 #endif


### PR DESCRIPTION
This is a bug which causes resolution to fail on systems, where a nameserver-entry in /etc/resolv.conf contains a comment at the end of the line.
For example on Unraid:
```
# Generated by rc.inet1
nameserver 8.8.8.8  # eth0:v4
```
causes:
```
Network.Socket.getAddrInfo (called with preferred socket type/protocol: AddrInfo {addrFlags = [AI_ADDRCONFIG,AI_NUMERICHOST,AI_NUMERICSERV,AI_PASSIVE], addrFamily = AF_UNSPEC, addrSocketType = Datagram, addrProtocol = 0, addrAddress = 0.0.0.0:0, addrCanonName = Nothing}, host name: "8.8.8.8 # eth0:v4", service name: "53"): does not exist (Name or service not known)
```
This bug is also present in the original dns repository.