### PR TITLE
ci: fix brew version to monotonically increase

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,6 +138,7 @@ jobs:
       if: steps.params.outputs.release_brew == 'true' && matrix.ghc == '9.6'
       run: |
         echo version=${{ github.ref_name }} >> "$GITHUB_OUTPUT"
+        echo brew_version=$(date +%Y%m%d) >> "$GITHUB_OUTPUT"
     - name: trigger Homebrew formulae update
       uses: peter-evans/repository-dispatch@v1
       if: steps.params.outputs.release_brew == 'true' && matrix.ghc == '9.6'
@@ -145,4 +146,4 @@ jobs:
         token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         repository: iijlab/homebrew-tap
         event-type: update-brew
-        client-payload: '{ "url": "${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/dug-mac-arm64", "sha256": "${{ steps.checksum.outputs.sha256 }}", "version": "${{ steps.version.outputs.version }}" }'
+        client-payload: '{ "url": "${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/dug-mac-arm64", "sha256": "${{ steps.checksum.outputs.sha256 }}", "version": "${{ steps.version.outputs.brew_version }}" }'


### PR DESCRIPTION
without this commit, the version string of each homebrew release uses the name of github release (e.g. `hotfix-20250903-02`) which may not be able to detect if the release is newer or not (because brew seems like to use the numerical values to detect).  This commit fixes it.

it uses the output of date command, which means older brew release on a day will be overwritten by newer one.