### PR TITLE
dug: -f short option

### DIFF
--- a/dnsext-bowline/dug/Output.hs
+++ b/dnsext-bowline/dug/Output.hs
@@ -44,7 +44,16 @@ resultShort :: Printer DNSMessage
 resultShort DNSMessage{..} = rrsShort answer
 
 rrsShort :: Printer [ResourceRecord]
-rrsShort rs = mapM_ rrShort rs
+rrsShort [] = return ()
+rrsShort (r0 : rs0) = do
+    rrShort r0
+    loop rs0
+  where
+    loop [] = return ()
+    loop (r : rs) = do
+        nl
+        rrShort r
+        loop rs
 
 rrShort :: Printer ResourceRecord
 rrShort ResourceRecord{..} = do
@@ -52,7 +61,6 @@ rrShort ResourceRecord{..} = do
     string . prettyRData =<< getFlags
     let keyTag dnskey = string (" (key_tag: " ++ show (Verify.keyTag dnskey) ++ ")")
     maybe (pure ()) keyTag $ fromRData rdata
-    nl
 
 ----------------------------------------------------------------
 

--- a/dnsext-bowline/dug/Recursive.hs
+++ b/dnsext-bowline/dug/Recursive.hs
@@ -179,7 +179,7 @@ recursiveQuery ips port putLnSTM putLinesSTM qcs opt@Options{..} tq = do
         if optDoX == "auto"
             then resolveDDR opt conf
             else resolveDoX opt ris
-    let printHeader = optFormat /= JSONstyle
+    let printHeader = optFormat `notElem` [Short, JSONstyle]
     if null pipes
         then runUDP printHeader conf putLnSTM putLinesSTM qcs
         else runVC printHeader pipes putLnSTM putLinesSTM qcs

--- a/dnsext-bowline/dug/dug.hs
+++ b/dnsext-bowline/dug/dug.hs
@@ -179,7 +179,7 @@ main = do
             opts <- checkFallbackV4 opts1 [(ip, 53) | (ip, _) <- ips]
             recursiveQuery ips port putLnSTM putLinesSTM qs opts tq
     ------------------------
-    when (optFormat /= JSONstyle) $ putTime t0 putLines
+    when (optFormat `notElem` [Short, JSONstyle]) $ putTime t0 putLines
     killLogger
     sentinel tq
     deprecated
@@ -296,6 +296,7 @@ mkPutline format putLinesSTM msg = putLinesSTM Log.WARN Nothing [res msg]
     res = case format of
         JSONstyle -> showJSON
         Singleline -> pprResult []
+        Short -> pprResult [Short]
         Multiline -> pprResult [Multiline]
 
 ----------------------------------------------------------------
@@ -389,6 +390,7 @@ convDoX dox = case dox' of
 convOutputFlag :: String -> OutputFlag
 convOutputFlag "json"  = JSONstyle
 convOutputFlag "multi" = Multiline
+convOutputFlag "short" = Short
 convOutputFlag _       = Singleline
 
 ----------------------------------------------------------------

--- a/dnsext-bowline/dug/dug.hs
+++ b/dnsext-bowline/dug/dug.hs
@@ -153,7 +153,7 @@ main = do
         putStr $ usageInfo msg options
         putStr "\n"
         putStrLn "  <proto>     = auto | tcp | dot | doq | h2 | h2c | h3"
-        putStrLn "  <format>    = multi | json"
+        putStrLn "  <format>    = multi | json | short"
         putStrLn "  <verbosity> = 0 | 1 | 2 | 3"
         exitSuccess
     ------------------------


### PR DESCRIPTION
With this patch, the following script works well:

```shell
doms=$(cat dom-list.txt)
for dom in $doms; do
  printf '%s' $dom
  n=$(dug -f short $dom a | wc -l | awk '{print $1}')
  if [ $n -ne 0 ]; then
      printf ' a'
      if dug -f short $dom https | grep 'ech=' 1> /dev/null 2>&1; then
        printf ' ech'
      fi
  fi
  printf '\n'
done
```